### PR TITLE
Fix typo

### DIFF
--- a/source/guide/transitions.md
+++ b/source/guide/transitions.md
@@ -168,9 +168,9 @@ enter: function (el, done) {
 
 ## CSS アニメーション
 
-CSS アニメーションは、CSS トランジションと同じやり方で適用することができますが、対処の要素が追加された後、`animationend` がコールバックされるまで `v-enter` クラスが削除されないという違いがあります。
+CSS アニメーションは、CSS トランジションと同じやり方で適用することができますが、対象の要素が追加された後、`animationend` がコールバックされるまで `v-enter` クラスが削除されないという違いがあります。
 
-**例：** (CSS ルールの記述は諸略)
+**例：** (CSS ルールの記述は省略)
 
 ``` html
 <span v-if="show" v-transition="bounce">Look at me!</span>


### PR DESCRIPTION
`/guide/transitions.html` の typo 修正です。
