### PR TITLE
Fix typo and translation at application guide

### DIFF
--- a/source/guide/application.md
+++ b/source/guide/application.md
@@ -124,7 +124,7 @@ Vue.js の縮小されたスタンドアローンビルド版は、既に小さ�
 
 ### Webpack
 
-警告ブロックが自動的に UglifyJS によって縮小中を削除できるように、プロダクション環境を示すために Webpack の [DefinePlugin](http://webpack.github.io/docs/list-of-plugins.html#defineplugin) を使ってください。設定例:
+警告ブロックが自動的に UglifyJS によって縮小中に削除されるように、プロダクション環境を示すために Webpack の [DefinePlugin](http://webpack.github.io/docs/list-of-plugins.html#defineplugin) を使ってください。設定例:
 
 ``` js
 var webpack = require('webpack')

--- a/source/guide/application.md
+++ b/source/guide/application.md
@@ -59,7 +59,7 @@ app.currentView = 'page1'
 
 ## サーバーとの通信
 
-すべての Vue インスタンスは、`JSON.stringify()` で直接シリアライズされる生の `$data` を持つことができます。Vue.js コミュニティは [vue-resource](https://github.com/vuejs/vue-resource) プラグインを貢献していて、RESTFul API で動作するため簡単な方法を提供します。例えば jQuery の `$.ajax` または [SuperAgent](https://github.com/visionmedia/superagent) などの好きな Ajax ライブラリも使用できます。Vue.js はバックエンドを持たない Firebase や Parse などのサービスとの連携にも適しています。
+すべての Vue インスタンスは、`JSON.stringify()` で直接シリアライズされる生の `$data` を持つことができます。Vue.js コミュニティは [vue-resource](https://github.com/vuejs/vue-resource) プラグインに貢献していて、RESTFul API で動作するため簡単な方法を提供します。例えば jQuery の `$.ajax` または [SuperAgent](https://github.com/visionmedia/superagent) などの好きな Ajax ライブラリも使用できます。Vue.js はバックエンドを持たない Firebase や Parse などのサービスとの連携にも適しています。
 
 ## 単体テスト
 


### PR DESCRIPTION
`guide/application.html` の typo 修正と、翻訳修正です。

> so that warning blocks can be automatically dropped by UglifyJS during minification.

`警告ブロックが自動的に UglifyJS によって縮小中を削除できるように`   → `警告ブロックが自動的に UglifyJS によって縮小中に削除されるように`
