### PR TITLE
Fix typo

### DIFF
--- a/source/guide/extending.md
+++ b/source/guide/extending.md
@@ -54,7 +54,7 @@ CommonJS ベースのビルドを行っていると仮定します。
 
 ``` js
 var vueTouch = require('vue-touch')
-// プラグインをグルーバルで使用
+// プラグインをグローバルで使用
 Vue.use(vueTouch)
 ```
 


### PR DESCRIPTION
`guide/extending.html` の typo の修正です。
